### PR TITLE
chore: force upgrade twine to fix semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ after_script:
 jobs:
   include:
     - stage: semantic release
-      python: "3.6"
+      python: "2.7"
       script: ./bin/semantic-release

--- a/bin/semantic-release
+++ b/bin/semantic-release
@@ -4,6 +4,7 @@ if [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_BRANCH" = master ] ; then
     git config --global user.name "semantic-release"
     git config --global user.email "semantic-release@travis"
     pip install python-semantic-release
+    pip install -U twine
     semantic-release publish
 else
     echo "Branch: Skipping release"


### PR DESCRIPTION
#### :rocket: Why this change?
Semantic-release failed to publish last version, since it was using a deprecated pypi API that was removed. Semantic-release uses Twine as Pypi client, but it's pinned to a very old version.
This forces a twine upgrade after installing semantic release.

Also changed the release environment to be 2.7, since it's pre-installed in Travis, and it will run faster.

#### :memo: Related issues and Pull Requests
This is needed until this PR gets merged (if it ever gets merged): 
https://github.com/relekang/python-semantic-release/pull/69

This is the build that failed to publish: https://travis-ci.org/argos83/marvin/jobs/252767358

#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Commits](http://conventionalcommits.org/) prefixes in front of all my commits