### PR TITLE
chore: fix missing comma in setup.py

### DIFF
--- a/bin/semantic-release
+++ b/bin/semantic-release
@@ -3,8 +3,7 @@ if [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_BRANCH" = master ] ; then
     echo "Releasing new version of Marvin"
     git config --global user.name "semantic-release"
     git config --global user.email "semantic-release@travis"
-    pip install python-semantic-release
-    pip install -U twine
+    pip install -U python-semantic-release
     semantic-release publish
 else
     echo "Branch: Skipping release"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='marvin-test',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5'
+          'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6'
       ]
 )


### PR DESCRIPTION
#### :rocket: Why this change?
* invalid setup.py file, failing releases
* use remove twine pinning since semantic-release has been fixed

#### :memo: Related issues and Pull Requests

https://github.com/relekang/python-semantic-release/pull/72

#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Commits](http://conventionalcommits.org/) prefixes in front of all my commits