### PR TITLE
Fix report and data key issue

### DIFF
--- a/marvin/data/iteration_data.py
+++ b/marvin/data/iteration_data.py
@@ -3,7 +3,7 @@ class IterationData(object):
     Models an iteration data and meta data.
     """
 
-    def __init__(self, data=None, name=None, description=None, tags=None):
+    def __init__(self, data=None, name=None, description=None, tags=None, **_kwargs):
         self._data = data
         self._name = name
         self._description = description

--- a/marvin/report/observers/event_logger.py
+++ b/marvin/report/observers/event_logger.py
@@ -90,7 +90,7 @@ class EventLogger(object):
         if event.status == Status.SKIP and event.exception[0] == ContextSkippedException:
             self._p("%sSkip reason: %s", indent, event.exception[1].reason)
         elif event.status != Status.PASS and event.exception[2]:
-            self._p(self._format_exception(event.exception))
+            self._p("%s", self._format_exception(event.exception))
 
     def on_test_started(self, event):
         test_script = event.test_script
@@ -126,7 +126,7 @@ class EventLogger(object):
             iall = ipass + ifail + iskip
             iteration_summary = "%d iteration(s) (%d pass - %d fail - %d skip)" % (iall, ipass, ifail, iskip)
             self._p("[%s] %s: %s", status, test['name'], iteration_summary)
-            [self._p(exception) for exception in test['exceptions']]
+            [self._p("%s", exception) for exception in test['exceptions']]
 
     def _get_phase_suffix(self, event):
         suffix = ""

--- a/tests/resources/data/iterations_unexpected_keys.yaml
+++ b/tests/resources/data/iterations_unexpected_keys.yaml
@@ -1,0 +1,13 @@
+name: Test unexpected keys
+description: Should not fail
+tags: [bunch, of, tags]
+
+setup_data:
+  a_list: [1, 2]
+
+iterations:
+  - name: First iteration
+    unexpected_key: no_data_key
+
+tear_down_data:
+  foo: baz

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -104,3 +104,16 @@ def test_unimplemented_file_data_provider():
 
     with pytest.raises(NotImplementedError):
         DummyFileDataProvider(r('data/example.json'))
+
+
+def test_iterations_no_data_key_and_unexpected_keys():
+    data = DataProviderRegistry.data_provider_for(r('data/iterations_unexpected_keys.yaml'))
+    assert data.name == 'Test unexpected keys'
+    assert data.description == 'Should not fail'
+    assert data.tags == {'bunch', 'of', 'tags'}
+    assert data.setup_data == {'a_list': [1, 2]}
+    iterations = [(i.name, i.description, i.tags, i.data) for i in data.iterations]
+    assert iterations == [
+        ('First iteration', None, None, None)
+    ]
+    assert data.tear_down_data == {'foo': 'baz'}


### PR DESCRIPTION
#### :rocket: Why this change?
There were two errors:
- Marvin failed when there was no "data" key and extra keys on iterations
- Marvin failed when trying to show exceptions on execution summary

#### :memo: Related issues and Pull Requests
#28 
#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [X] To write tests
- [X] To put [Conventional Commits](http://conventionalcommits.org/) prefixes in front of all my commits